### PR TITLE
Put binary inside a directory inside binary release archive and fix permission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 go:
   - "1.10"
 
+before_script:
+  - umask 022
 script:
   - GOOS=linux GOARCH=amd64 go build -o lxd_exporter.linux-amd64/lxd_exporter
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,16 @@ go:
   - "1.10"
 
 script:
-  - GOOS=linux GOARCH=amd64 go build -o lxd-exporter
+  - GOOS=linux GOARCH=amd64 go build -o lxd_exporter.linux-amd64/lxd_exporter
 
 before_deploy:
-  - tar -zcf lxd-exporter-linux-amd64.tar.gz lxd-exporter
+  - tar -zcf lxd_exporter.linux-amd64.tar.gz lxd_exporter.linux-amd64
 deploy:
   provider: releases
   skip_cleanup: true
   api_key: $GITHUB_TOKEN
   file:
-    - lxd-exporter-linux-amd64.tar.gz
+    - lxd_exporter.linux-amd64.tar.gz
   on:
     repo: BaritoLog/lxd_exporter
     tags: true


### PR DESCRIPTION
This is one of the available solutions to fix #3 and #4.

#### Update structure of binary release
This commit encapsulates the binary inside a directory, so `ark` cookbook can extract it properly, and the way to extract this exporter will be the same as extracting the other exporter.

Current archive directory layout:
```
$ tar -tf lxd_exporter.tar.gz
lxd-exporter
```

Proposed archive directory layout:
```
$ tar -tf lxd_exporter.linux-amd64.tar.gz
lxd_exporter.linux-amd64/
lxd_exporter.linux-amd64/lxd_exporter
```

This pull request has been tested [here](https://github.com/nieltg/lxdexporter_golang/releases/tag/v1.2). If everything is good, please redoes the release after merging this PR.

#### Update permission
Permission is updated by setting `umask` on Travis CI environment, so Travis CI will produces binary with consistent permission.

Reference: [File permissions just gone up to 664 - Environments / Linux - Travis CI Community](https://travis-ci.community/t/file-permissions-just-gone-up-to-664/1547)