### PR TITLE
Use kingpin.Flag instead of Arg for port param.

### DIFF
--- a/cmd/lxd_exporter/main.go
+++ b/cmd/lxd_exporter/main.go
@@ -16,7 +16,7 @@ import (
 var (
 	version = "staging-UNVERSIONED"
 
-	port = kingpin.Arg(
+	port = kingpin.Flag(
 		"port", "Provide the port to listen on").Default("9472").Int16()
 )
 


### PR DESCRIPTION
`--port` is `Flag` in kingpin library.

Corresponding issue: #9.